### PR TITLE
Switch to `scheduleWithFixedDelay` to combat bursts

### DIFF
--- a/jda-nas/src/main/java/com/sedmelluq/discord/lavaplayer/jdaudp/NativeAudioSendFactory.java
+++ b/jda-nas/src/main/java/com/sedmelluq/discord/lavaplayer/jdaudp/NativeAudioSendFactory.java
@@ -30,7 +30,7 @@ public class NativeAudioSendFactory implements IAudioSendFactory {
     queueManager = new UdpQueueManager(BUFFER_DURATION / PACKET_INTERVAL,
         TimeUnit.MILLISECONDS.toNanos(PACKET_INTERVAL), MAXIMUM_PACKET_SIZE);
 
-    scheduler.scheduleAtFixedRate(this::populateQueues, 0, 40, TimeUnit.MILLISECONDS);
+    scheduler.scheduleWithFixedDelay(this::populateQueues, 0, 40, TimeUnit.MILLISECONDS);
 
     Thread thread = new Thread(queueManager::process);
     thread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);


### PR DESCRIPTION
In a sufficiently large GC pause, with a sufficiently large amount of
concurrent players, the pool will have missed a sufficiently large
amount of ticks.

To compensate, it runs the piled up ticks anyway, but this is
unnecessary, as no packets will have drained from the queue.